### PR TITLE
Revert commit that broke PostfixToInfix()

### DIFF
--- a/implementation.go
+++ b/implementation.go
@@ -53,5 +53,5 @@ func PostfixToInfix(input string) (string, error) {
 	if len(stack) != 1 {
 		return "", fmt.Errorf("invalid postfix expression")
 	}
-	return stack[0].expr + " some string to fail tests", nil
+	return stack[0].expr, nil
 }


### PR DESCRIPTION
This reverts commit e0b3ca00525519ee4d0a7f407613054ff8afafd2.